### PR TITLE
add support for specifying systemd-resolved fallback dns

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,4 @@ systemd_resolved_dnsovertls: false
 systemd_resolved_cache: true
 systemd_resolved_dnsstublistener: "udp"
 systemd_resolved_readetchosts: true
+systemd_resolved_fallback_dns: []

--- a/templates/resolved.conf.j2
+++ b/templates/resolved.conf.j2
@@ -5,6 +5,9 @@ DNS = {{ systemd_resolved_dns | join(' ') }}
 {% else %}
 DNS = {{ ansible_default_ipv4.gateway }}
 {% endif %}
+{% if (systemd_resolved_fallback_dns  | length) > 0 %}
+FallbackDNS = {{ systemd_resolved_fallback_dns | join(' ') }}
+{% endif %}
 Domains = {{ systemd_resolved_domains | join(' ') }}
 LLMNR = {{ systemd_resolved_llmnr }}
 MulticastDNS = {{ systemd_resolved_multicastdns }}


### PR DESCRIPTION
Hi, I'd just like to add a small improvement to the role to allow specifying the FallbackDNS option from https://www.freedesktop.org/software/systemd/man/resolved.conf.html